### PR TITLE
Caching registry fetch errors forever leads to PODs ending needing re…

### DIFF
--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -1,0 +1,15 @@
+package avroregistry
+
+import (
+	"fmt"
+)
+
+// UnavailableError reports an error when the schema registry is unavailable.
+type UnavailableError struct {
+	Cause error
+}
+
+// Error implements the error interface.
+func (m *UnavailableError) Error() string {
+	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
+}

--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -13,3 +13,8 @@ type UnavailableError struct {
 func (m *UnavailableError) Error() string {
 	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
 }
+
+// Unwrap unwraps and return Cause error. It is needed to properly handle %w usage in fmt.Errorf cases.
+func (e *UnavailableError) Unwrap() error {
+	return e.Cause
+}

--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -14,7 +14,7 @@ func (m *UnavailableError) Error() string {
 	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
 }
 
-// Unwrap unwraps and return Cause error. It is needed to properly handle %w usage in fmt.Errorf cases.
+// Unwrap unwraps and return Cause error. It is needed to properly handle and compare errors.
 func (e *UnavailableError) Unwrap() error {
 	return e.Cause
 }

--- a/avroregistry/errors_test.go
+++ b/avroregistry/errors_test.go
@@ -1,0 +1,34 @@
+package avroregistry_test
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro/avroregistry"
+)
+
+func TestUnavailableError_Unwrap(t *testing.T) {
+	c := qt.New(t)
+	var ErrExpect = errors.New("error")
+
+	err := &avroregistry.UnavailableError{
+		Cause: ErrExpect,
+	}
+
+	c.Assert(errors.Is(err, ErrExpect), qt.IsTrue)
+
+	var newErr *avroregistry.UnavailableError
+	c.Assert(errors.As(err, &newErr), qt.IsTrue)
+}
+
+func TestUnavailableError_Error(t *testing.T) {
+	c := qt.New(t)
+
+	err := &avroregistry.UnavailableError{
+		Cause: errors.New("ECONNREFUSED"),
+	}
+
+	c.Assert(err.Error(), qt.Equals, "schema registry unavailability caused by: ECONNREFUSED")
+}

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -210,6 +210,12 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			} else {
 				return apiErr
 			}
+		} else {
+			// some 5XX response body cannot be decoded
+			// hence an *apiError is not returned
+			if resp.StatusCode/100 == 5 {
+				err = &UnavailableError{err}
+			}
 		}
 
 		if !attempt.More() {

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			if !attempt.More() || !isTemporaryError(err) {
-				return err
+				return &UnavailableError{err}
 			}
 			continue
 		}
@@ -201,7 +201,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 		if !attempt.More() {
 			return err
 		}
-		if err, ok := err.(*apiError); ok && err.StatusCode/100 != 5 {
+		if err, ok := err.(*apiError); ok && err.StatusCode != http.StatusInternalServerError {
 			// It's not a 5xx error. We want to retry on 5xx
 			// errors, because the Confluent Avro registry
 			// can occasionally return them as a matter of

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -199,7 +199,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			return nil
 		}
 		if !attempt.More() {
-			return err
+			return &UnavailableError{err}
 		}
 		if err, ok := err.(*apiError); ok && err.StatusCode != http.StatusInternalServerError {
 			// It's not a 5xx error. We want to retry on 5xx
@@ -208,6 +208,9 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			// course (and there could also be an
 			// unavailable service that we're reaching
 			// through a proxy).
+			if !attempt.More() {
+				return &UnavailableError{err}
+			}
 			return err
 		}
 	}

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -206,9 +206,9 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			// unavailable service that we're reaching
 			// through a proxy).
 			if apiErr.StatusCode/100 == 5 {
-				return apiErr
-			} else {
 				err = &UnavailableError{apiErr}
+			} else {
+				return apiErr
 			}
 		}
 

--- a/avroregistry/registry_test.go
+++ b/avroregistry/registry_test.go
@@ -340,7 +340,7 @@ func TestRetryOn500(t *testing.T) {
 	// an error.
 	failCount = 5
 	err = registry.SetCompatibility(context.Background(), "x", avro.BackwardTransitive)
-	c.Assert(err, qt.ErrorMatches, `Avro registry error \(code 50001; HTTP status 500\): Failed to update compatibility level`)
+	c.Assert(err, qt.ErrorMatches, `schema registry unavailability caused by: Avro registry error \(code 50001; HTTP status 500\): Failed to update compatibility level`)
 }
 
 func TestNoRetryOnNon5XXStatus(t *testing.T) {
@@ -392,7 +392,7 @@ func TestUnavailableError(t *testing.T) {
 	})
 	c.Assert(err, qt.Equals, nil)
 	err = registry.SetCompatibility(context.Background(), "x", avro.BackwardTransitive)
-	c.Assert(err, qt.ErrorMatches, `cannot unmarshal JSON error response from .*/config/x: unexpected content type text/html; want application/json; content: 502 Proxy Error; Proxy Error; The whole world is bogus`)
+	c.Assert(err, qt.ErrorMatches, `schema registry unavailability caused by: cannot unmarshal JSON error response from .*/config/x: unexpected content type text/html; want application/json; content: 502 Proxy Error; Proxy Error; The whole world is bogus`)
 }
 
 var schemaEquivalenceTests = []struct {

--- a/gotype.go
+++ b/gotype.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/actgardner/gogen-avro/v10/schema"
 
@@ -29,7 +30,8 @@ var globalNames = new(Names)
 // In fact it just holds an error so that we can cache errors.
 type errorSchema struct {
 	schema.AvroType
-	err error
+	err          error
+	invalidAfter time.Time
 }
 
 // TypeOf returns the Avro type for the Go type of x.
@@ -40,30 +42,30 @@ type errorSchema struct {
 // Otherwise TypeOf(T) is derived according to
 // the following rules:
 //
-//	- int, int64 and uint32 encode as "long"
-//	- int32, int16, uint16, int8 and uint8 encode as "int"
-//	- float32 encodes as "float"
-//	- float64 encodes as "double"
-//	- string encodes as "string"
-//	- Null{} encodes as "null"
-//	- time.Duration encodes as {"type": "long", "logicalType": "duration-nanos"}
-//	- time.Time encodes as {"type": "long", "logicalType": "timestamp-micros"}
-//	- github.com/google/uuid.UUID encodes as {"type": "string", "logicalType": "string"}
-//	- [N]byte encodes as {"type": "fixed", "name": "go.FixedN", "size": N}
-//	- a named type with underlying type [N]byte encodes as [N]byte but typeName(T) for the name.
-//	- []T encodes as {"type": "array", "items": TypeOf(T)}
-//	- map[string]T encodes as {"type": "map", "values": TypeOf(T)}
-//	- *T encodes as ["null", TypeOf(T)]
-//	- a named struct type encodes as {"type": "record", "name": typeName(T), "fields": ...}
-//		where the fields are encoded as described below.
-//	- interface types are disallowed.
+//   - int, int64 and uint32 encode as "long"
+//   - int32, int16, uint16, int8 and uint8 encode as "int"
+//   - float32 encodes as "float"
+//   - float64 encodes as "double"
+//   - string encodes as "string"
+//   - Null{} encodes as "null"
+//   - time.Duration encodes as {"type": "long", "logicalType": "duration-nanos"}
+//   - time.Time encodes as {"type": "long", "logicalType": "timestamp-micros"}
+//   - github.com/google/uuid.UUID encodes as {"type": "string", "logicalType": "string"}
+//   - [N]byte encodes as {"type": "fixed", "name": "go.FixedN", "size": N}
+//   - a named type with underlying type [N]byte encodes as [N]byte but typeName(T) for the name.
+//   - []T encodes as {"type": "array", "items": TypeOf(T)}
+//   - map[string]T encodes as {"type": "map", "values": TypeOf(T)}
+//   - *T encodes as ["null", TypeOf(T)]
+//   - a named struct type encodes as {"type": "record", "name": typeName(T), "fields": ...}
+//     where the fields are encoded as described below.
+//   - interface types are disallowed.
 //
 // Struct fields are encoded as follows:
 //
-//	- unexported struct fields are ignored
-//	- the field name is taken from the Go field name, or from a "json" tag for the field if present.
-//	- the default value for the field is the zero value for the type.
-//	- anonymous struct fields are disallowed (this restriction may be lifted in the future).
+//   - unexported struct fields are ignored
+//   - the field name is taken from the Go field name, or from a "json" tag for the field if present.
+//   - the default value for the field is the zero value for the type.
+//   - anonymous struct fields are disallowed (this restriction may be lifted in the future).
 func TypeOf(x interface{}) (*Type, error) {
 	return globalNames.TypeOf(x)
 }

--- a/singledecoder.go
+++ b/singledecoder.go
@@ -92,7 +92,7 @@ func (c *SingleDecoder) Unmarshal(ctx context.Context, data []byte, x interface{
 	}
 	prog, err := c.getProgram(ctx, vt, wID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshal: %v", err)
+		return nil, fmt.Errorf("cannot unmarshal: %w", err)
 	}
 	return unmarshal(nil, body, prog, v)
 }


### PR DESCRIPTION
…start to fix temporary errors like routing after redeploy.

- Cache fetch errors for one minute to avoid overloading registry server.
- Should fix context cancelled loops seen after redeploy.